### PR TITLE
Fix some issues in signal

### DIFF
--- a/src/amulet/utils/signal/signal.hpp
+++ b/src/amulet/utils/signal/signal.hpp
@@ -178,7 +178,7 @@ public:
             } break;
             case ConnectionMode::Async: {
                 if (!async_args) {
-                    async_args = std::make_shared<std::tuple<Args...>>(std::forward<Args>(args)...);
+                    async_args = std::make_shared<std::tuple<Args...>>(args...);
                 }
                 detail::get_global_event_loop().submit([async_args, ptr]() {
                     auto storage = ptr.lock();

--- a/src/amulet/utils/signal/signal.py.hpp
+++ b/src/amulet/utils/signal/signal.py.hpp
@@ -4,7 +4,6 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/typing.h>
 
-#include <iostream>
 #include <memory>
 
 #include "signal.hpp"
@@ -50,12 +49,10 @@ void create_signal_binding()
                     py::gil_scoped_release nogil;
                     auto callback_wrapper = [callback, py_shut_down](auto... args) {
                         if (*py_shut_down) {
-                            std::cout << "pyfunc invalid" << std::endl;
                             throw std::runtime_error(
                                 "Cannot execute Python function connected to signal because the Python interpreter has been shut down. "
                                 "Python callbacks must be disconnected before the interpreter shuts down.");
                         } else {
-                            std::cout << "calling pyfunc" << std::endl;
                             callback(args...);
                         }
                     };

--- a/src/amulet/utils/signal/signal.py.hpp
+++ b/src/amulet/utils/signal/signal.py.hpp
@@ -46,7 +46,6 @@ void create_signal_binding()
                         py::cpp_function([py_shut_down]() {
                             (*py_shut_down) = true;
                         }));
-                    py::gil_scoped_release nogil;
                     auto callback_wrapper = [callback, py_shut_down](auto... args) {
                         if (*py_shut_down) {
                             throw std::runtime_error(
@@ -56,6 +55,7 @@ void create_signal_binding()
                             callback(args...);
                         }
                     };
+                    py::gil_scoped_release nogil;
                     return self.connect(callback_wrapper, mode);
                 },
                 py::arg("callback"),

--- a/src/amulet/utils/signal/signal.py.hpp
+++ b/src/amulet/utils/signal/signal.py.hpp
@@ -4,9 +4,12 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/typing.h>
 
+#include <iostream>
+#include <memory>
+
 #include "signal.hpp"
-#include <amulet/pybind11_extensions/pybind11.hpp>
 #include <amulet/pybind11_extensions/nogil_holder.hpp>
+#include <amulet/pybind11_extensions/pybind11.hpp>
 
 namespace py = pybind11;
 namespace pyext = Amulet::pybind11_extensions;
@@ -29,18 +32,37 @@ class PySignalToken : public py::object {
 template <typename signalT>
 void create_signal_binding()
 {
-    if (!pyext::is_class_bound<signalT>())
-        {
+    if (!pyext::is_class_bound<signalT>()) {
         pybind11::class_<typename signalT::tokenT>(pybind11::handle(), "SignalToken", pybind11::module_local());
 
         pybind11::class_<signalT, pyext::nogil_shared_ptr<signalT>>(pybind11::handle(), "Signal", pybind11::module_local())
             .def(
-                "connect", 
-                &signalT::connect, 
+                "connect",
+                [](signalT& self, typename signalT::callbackT callback, ConnectionMode mode) {
+                    // Bad things happen if this is called after python shuts down.
+                    // Add a wrapper to make sure python is still running.
+                    auto py_shut_down = std::make_shared<bool>(false);
+                    auto atexit = py::module::import("atexit");
+                    atexit.attr("register")(
+                        py::cpp_function([py_shut_down]() {
+                            (*py_shut_down) = true;
+                        }));
+                    py::gil_scoped_release nogil;
+                    auto callback_wrapper = [callback, py_shut_down](auto... args) {
+                        if (*py_shut_down) {
+                            std::cout << "pyfunc invalid" << std::endl;
+                            throw std::runtime_error(
+                                "Cannot execute Python function connected to signal because the Python interpreter has been shut down. "
+                                "Python callbacks must be disconnected before the interpreter shuts down.");
+                        } else {
+                            std::cout << "calling pyfunc" << std::endl;
+                            callback(args...);
+                        }
+                    };
+                    return self.connect(callback_wrapper, mode);
+                },
                 py::arg("callback"),
-                py::arg("mode") = Amulet::ConnectionMode::Direct,
-                py::call_guard<py::gil_scoped_release>()
-            )
+                py::arg("mode") = Amulet::ConnectionMode::Direct)
             .def("disconnect", &signalT::disconnect, py::call_guard<py::gil_scoped_release>())
             .def("emit", &signalT::emit, py::call_guard<py::gil_scoped_release>());
     }


### PR DESCRIPTION
Remove argument forwarding. I think this would leave the original state invalid.
Wrap signal callback to handle post-interpreter shutdown situation.