### PR TITLE
Improve Signal atexit handling

### DIFF
--- a/src/amulet/utils/_utils.py.cpp
+++ b/src/amulet/utils/_utils.py.cpp
@@ -1,6 +1,7 @@
 #include <pybind11/pybind11.h>
 
 #include <amulet/pybind11_extensions/compatibility.hpp>
+#include <amulet/utils/python.hpp>
 
 namespace py = pybind11;
 namespace pyext = Amulet::pybind11_extensions;
@@ -11,6 +12,11 @@ void init_logging(py::module);
 void init_module(py::module m)
 {
     pyext::init_compiler_config(m);
+
+    auto py_valid = Amulet::get_py_valid();
+    *py_valid = true;
+    py::module::import("atexit").attr("register")(
+        py::cpp_function([py_valid]() { *py_valid = false; }));
 
     // Submodules
     init_signal(m);

--- a/src/amulet/utils/python.cpp
+++ b/src/amulet/utils/python.cpp
@@ -1,0 +1,11 @@
+#include "python.hpp"
+
+namespace Amulet {
+
+std::shared_ptr<bool> get_py_valid()
+{
+    static std::shared_ptr<bool> _py_valid = std::make_shared<bool>(false);
+    return _py_valid;
+}
+
+} // namespace Amulet

--- a/src/amulet/utils/python.hpp
+++ b/src/amulet/utils/python.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <memory>
+
+#include <amulet/utils/dll.hpp>
+
+namespace Amulet {
+
+// Is the python interpreter valid.
+// This will be false before the interpreter starts and after it shuts down and true while it is running.
+AMULET_UTILS_EXPORT std::shared_ptr<bool> get_py_valid();
+
+} // namespace Amulet


### PR DESCRIPTION
Move python interpreter running bool.
Only one bool is needed for all signal connections and only needs on atexit call.