### PR TITLE
Improve logging and signal

### DIFF
--- a/src/amulet/utils/logging/logging.cpp
+++ b/src/amulet/utils/logging/logging.cpp
@@ -6,13 +6,15 @@
 
 namespace Amulet {
 
-static int min_log_level = 20;
-
-static void default_log_handler(int level, const std::string& msg)
+int& get_min_log_level()
 {
-    static std::mutex log_mutex;
-    std::unique_lock lock(log_mutex);
-    std::cout << msg << std::endl;
+    static int min_log_level = 20;
+    return min_log_level;
+}
+
+void set_min_log_level(int level)
+{
+    get_min_log_level() = level;
 }
 
 Amulet::Signal<int, std::string>& get_logger()
@@ -21,31 +23,9 @@ Amulet::Signal<int, std::string>& get_logger()
     return logger;
 }
 
-static Amulet::SignalToken<int, std::string> default_log_handler_token = get_logger().connect(&default_log_handler);
-
-void register_default_log_handler()
-{
-    default_log_handler_token = get_logger().connect(default_log_handler);
-}
-
-void unregister_default_log_handler()
-{
-    get_logger().disconnect(default_log_handler_token);
-}
-
-int get_min_log_level()
-{
-    return min_log_level;
-}
-
-void set_min_log_level(int level)
-{
-    min_log_level = level;
-}
-
 void log(int level, const std::string& msg)
 {
-    if (min_log_level <= level) {
+    if (get_min_log_level() <= level) {
         get_logger().emit(level, msg);
     }
 }
@@ -73,6 +53,25 @@ void error(const std::string& msg)
 void critical(const std::string& msg)
 {
     log(50, msg);
+}
+
+static void default_log_handler(int level, const std::string& msg)
+{
+    static std::mutex log_mutex;
+    std::unique_lock lock(log_mutex);
+    std::cout << msg << std::endl;
+}
+
+static Amulet::SignalToken<int, std::string> default_log_handler_token = get_logger().connect(&default_log_handler);
+
+void register_default_log_handler()
+{
+    default_log_handler_token = get_logger().connect(default_log_handler);
+}
+
+void unregister_default_log_handler()
+{
+    get_logger().disconnect(default_log_handler_token);
 }
 
 } // namespace Amulet

--- a/src/amulet/utils/logging/logging.cpp
+++ b/src/amulet/utils/logging/logging.cpp
@@ -22,7 +22,7 @@ static std::mutex& get_default_log_mutex() {
     return log_mutex;
 }
 
-static Amulet::SignalToken<int, std::string> get_default_log_handler_token() {
+static Amulet::SignalToken<int, std::string>& get_default_log_handler_token() {
     static Amulet::SignalToken<int, std::string> default_log_handler_token;
     return default_log_handler_token;
 }

--- a/src/amulet/utils/logging/logging.cpp
+++ b/src/amulet/utils/logging/logging.cpp
@@ -29,20 +29,17 @@ static Amulet::SignalToken<int, std::string>& get_default_log_handler_token() {
 
 static void default_log_handler(int level, const std::string& msg)
 {
-    std::cout << "log default" << std::endl;
     std::unique_lock lock(get_default_log_mutex());
     std::cout << msg << std::endl;
 }
 
 Amulet::Signal<int, std::string>& get_logger()
 {
-    std::cout << "get_logger" << std::endl;
     // Initialise dependent global variables
     get_min_log_level();
     get_default_log_mutex();
     get_default_log_handler_token();
     static Amulet::Signal<int, std::string> logger;
-    std::cout << "got_logger" << std::endl;
     // Setup the default log handler.
     static bool init_hanler = true;
     if (init_hanler) {
@@ -54,7 +51,6 @@ Amulet::Signal<int, std::string>& get_logger()
 
 void log(int level, const std::string& msg)
 {
-    std::cout << "log" << std::endl;
     if (get_min_log_level() <= level) {
         get_logger().emit(level, msg);
     }
@@ -62,31 +58,26 @@ void log(int level, const std::string& msg)
 
 void debug(const std::string& msg)
 {
-    std::cout << "debug" << std::endl;
     log(10, msg);
 }
 
 void info(const std::string& msg)
 {
-    std::cout << "info" << std::endl;
     log(20, msg);
 }
 
 void warning(const std::string& msg)
 {
-    std::cout << "warning" << std::endl;
     log(30, msg);
 }
 
 void error(const std::string& msg)
 {
-    std::cout << "error" << std::endl;
     log(40, msg);
 }
 
 void critical(const std::string& msg)
 {
-    std::cout << "critical" << std::endl;
     log(50, msg);
 }
 

--- a/src/amulet/utils/logging/logging.cpp
+++ b/src/amulet/utils/logging/logging.cpp
@@ -19,6 +19,7 @@ void set_min_log_level(int level)
 
 Amulet::Signal<int, std::string>& get_logger()
 {
+    get_min_log_level();
     static Amulet::Signal<int, std::string> logger;
     return logger;
 }

--- a/src/amulet/utils/logging/logging.cpp
+++ b/src/amulet/utils/logging/logging.cpp
@@ -42,26 +42,31 @@ void debug(const std::string& msg)
 
 void info(const std::string& msg)
 {
+    std::cout << "info" << std::endl;
     log(20, msg);
 }
 
 void warning(const std::string& msg)
 {
+    std::cout << "warning" << std::endl;
     log(30, msg);
 }
 
 void error(const std::string& msg)
 {
+    std::cout << "error" << std::endl;
     log(40, msg);
 }
 
 void critical(const std::string& msg)
 {
+    std::cout << "critical" << std::endl;
     log(50, msg);
 }
 
 static void default_log_handler(int level, const std::string& msg)
 {
+    std::cout << "log default" << std::endl;
     static std::mutex log_mutex;
     std::unique_lock lock(log_mutex);
     std::cout << msg << std::endl;

--- a/src/amulet/utils/logging/logging.cpp
+++ b/src/amulet/utils/logging/logging.cpp
@@ -19,13 +19,16 @@ void set_min_log_level(int level)
 
 Amulet::Signal<int, std::string>& get_logger()
 {
+    std::cout << "get_logger" << std::endl;
     get_min_log_level();
     static Amulet::Signal<int, std::string> logger;
+    std::cout << "got_logger" << std::endl;
     return logger;
 }
 
 void log(int level, const std::string& msg)
 {
+    std::cout << "log" << std::endl;
     if (get_min_log_level() <= level) {
         get_logger().emit(level, msg);
     }
@@ -33,6 +36,7 @@ void log(int level, const std::string& msg)
 
 void debug(const std::string& msg)
 {
+    std::cout << "debug" << std::endl;
     log(10, msg);
 }
 

--- a/src/amulet/utils/logging/logging.hpp
+++ b/src/amulet/utils/logging/logging.hpp
@@ -7,6 +7,10 @@
 
 namespace Amulet {
 
+// Forward declare Signal in case signal.hpp could not be included above.
+template <typename... Args>
+class Signal;
+
 // Register the default log handler.
 // This is registered by default with a log level of 20.
 // Thread safe.
@@ -19,7 +23,7 @@ AMULET_UTILS_EXPORT void unregister_default_log_handler();
 // Get the maximum message level that will be logged.
 // Registered handlers may be more strict.
 // Thread safe.
-AMULET_UTILS_EXPORT int get_min_log_level();
+AMULET_UTILS_EXPORT int& get_min_log_level();
 
 // Set the maximum message level that will be logged.
 // Registered handlers may be more strict.

--- a/src/amulet/utils/logging/logging.hpp
+++ b/src/amulet/utils/logging/logging.hpp
@@ -3,11 +3,10 @@
 #include <string>
 
 #include <amulet/utils/dll.hpp>
-#include <amulet/utils/signal/signal.hpp>
 
 namespace Amulet {
 
-// Forward declare Signal in case signal.hpp could not be included above.
+// Forward declare Signal
 template <typename... Args>
 class Signal;
 
@@ -60,3 +59,5 @@ AMULET_UTILS_EXPORT void error(const std::string& msg);
 AMULET_UTILS_EXPORT void critical(const std::string& msg);
 
 }
+
+#include <amulet/utils/signal/signal.hpp>

--- a/src/amulet/utils/logging/logging.hpp
+++ b/src/amulet/utils/logging/logging.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <iostream>
 #include <string>
 
 #include <amulet/utils/dll.hpp>
@@ -59,5 +60,14 @@ AMULET_UTILS_EXPORT void error(const std::string& msg);
 AMULET_UTILS_EXPORT void critical(const std::string& msg);
 
 }
+
+// Some places can't use the normal logging system.
+// This macro can be used to log directly.
+#define Log(level, msg)                     \
+    {                                       \
+        if (get_min_log_level() <= level) { \
+            std::cout << msg << std::endl;  \
+        }                                   \
+    }
 
 #include <amulet/utils/signal/signal.hpp>

--- a/src/amulet/utils/signal/signal.cpp
+++ b/src/amulet/utils/signal/signal.cpp
@@ -12,21 +12,20 @@ namespace detail {
     EventLoop::EventLoop()
         : _thread(&EventLoop::_event_loop, this)
     {
+        // This class may call debug during shutdown.
+        // Ensure the logger outlives the EventLoop.
+        Amulet::get_logger();
     }
 
     EventLoop::~EventLoop()
     {
-        if (get_min_log_level() <= 10) {
-            std::cout << "EventLoop::~EventLoop() enter" << std::endl;
-        }
+        debug("EventLoop::~EventLoop() enter");
         exit();
     }
 
     void EventLoop::exit()
     {
-        if (get_min_log_level() <= 10) {
-            std::cout << "EventLoop::exit()" << std::endl;
-        }
+        debug("EventLoop::exit()");
         {
             std::unique_lock lock(_mutex);
             if (_exit) {
@@ -35,13 +34,9 @@ namespace detail {
             _exit = true;
             _condition.notify_one();
         }
-        if (get_min_log_level() <= 10) {
-            std::cout << "EventLoop::exit() join" << std::endl;
-        }
+        debug("EventLoop::exit() join");
         _thread.join();
-        if (get_min_log_level() <= 10) {
-            std::cout << "EventLoop::exit() exit" << std::endl;
-        }
+        debug("EventLoop::exit() exit");
     }
 
     void EventLoop::_event_loop()
@@ -66,9 +61,7 @@ namespace detail {
             }
             lock.lock();
         }
-        if (get_min_log_level() <= 10) {
-            std::cout << "Exiting event loop" << std::endl;
-        }
+        debug("Exiting event loop");
     }
 
     void EventLoop::submit(std::function<void()> event)

--- a/src/amulet/utils/signal/signal.cpp
+++ b/src/amulet/utils/signal/signal.cpp
@@ -19,14 +19,12 @@ namespace detail {
 
     EventLoop::~EventLoop()
     {
-        std::cout << "EventLoop::~EventLoop() enter" << std::endl;
         debug("EventLoop::~EventLoop() enter");
         exit();
     }
 
     void EventLoop::exit()
     {
-        std::cout << "EventLoop::exit()" << std::endl;
         debug("EventLoop::exit()");
         {
             std::unique_lock lock(_mutex);
@@ -36,10 +34,8 @@ namespace detail {
             _exit = true;
             _condition.notify_one();
         }
-        std::cout << "EventLoop::exit() join" << std::endl;
         debug("EventLoop::exit() join");
         _thread.join();
-        std::cout << "EventLoop::exit() exit" << std::endl;
         debug("EventLoop::exit() exit");
     }
 
@@ -59,15 +55,12 @@ namespace detail {
             try {
                 event();
             } catch (const std::exception& e) {
-                std::cout << std::string("Unhandled exception in event loop: ") + e.what() << std::endl;
                 Amulet::error(std::string("Unhandled exception in event loop: ") + e.what());
             } catch (...) {
-                std::cout << "Unhandled exception in event loop." << std::endl;
                 Amulet::error("Unhandled exception in event loop.");
             }
             lock.lock();
         }
-        std::cout << "EventLoop::_event_loop() exit" << std::endl;
         debug("EventLoop::_event_loop() exit");
     }
 

--- a/src/amulet/utils/signal/signal.cpp
+++ b/src/amulet/utils/signal/signal.cpp
@@ -59,8 +59,10 @@ namespace detail {
             try {
                 event();
             } catch (const std::exception& e) {
+                std::cout << std::string("Unhandled exception in event loop: ") + e.what() << std::endl;
                 Amulet::error(std::string("Unhandled exception in event loop: ") + e.what());
             } catch (...) {
+                std::cout << "Unhandled exception in event loop." << std::endl;
                 Amulet::error("Unhandled exception in event loop.");
             }
             lock.lock();

--- a/src/amulet/utils/signal/signal.cpp
+++ b/src/amulet/utils/signal/signal.cpp
@@ -19,12 +19,14 @@ namespace detail {
 
     EventLoop::~EventLoop()
     {
+        std::cout << "EventLoop::~EventLoop() enter" << std::endl;
         debug("EventLoop::~EventLoop() enter");
         exit();
     }
 
     void EventLoop::exit()
     {
+        std::cout << "EventLoop::exit()" << std::endl;
         debug("EventLoop::exit()");
         {
             std::unique_lock lock(_mutex);
@@ -34,8 +36,10 @@ namespace detail {
             _exit = true;
             _condition.notify_one();
         }
+        std::cout << "EventLoop::exit() join" << std::endl;
         debug("EventLoop::exit() join");
         _thread.join();
+        std::cout << "EventLoop::exit() exit" << std::endl;
         debug("EventLoop::exit() exit");
     }
 
@@ -61,7 +65,8 @@ namespace detail {
             }
             lock.lock();
         }
-        debug("Exiting event loop");
+        std::cout << "EventLoop::_event_loop() exit" << std::endl;
+        debug("EventLoop::_event_loop() exit");
     }
 
     void EventLoop::submit(std::function<void()> event)

--- a/src/amulet/utils/signal/signal.hpp
+++ b/src/amulet/utils/signal/signal.hpp
@@ -13,9 +13,6 @@
 
 namespace Amulet {
 
-// Forward declare error in case logging.hpp could not be included above.
-AMULET_UTILS_EXPORT void error(const std::string& msg);
-
 enum class ConnectionMode {
     Direct, // Directly called by the emitter.
     Async, // Called asynchronously.

--- a/src/amulet/utils/signal/signal.hpp
+++ b/src/amulet/utils/signal/signal.hpp
@@ -178,8 +178,10 @@ public:
                 try {
                     storage->callback(args...);
                 } catch (const std::exception& e) {
+                    std::cout << std::string("Error in callback: ") + e.what() << std::endl;
                     error(std::string("Error in callback: ") + e.what());
                 } catch (...) {
+                    std::cout << "Error in callback." << std::endl;
                     error("Error in callback.");
                 }
             } break;
@@ -201,9 +203,11 @@ public:
                     try {
                         std::apply(storage->callback, *async_args);
                     } catch (const std::exception& e) {
-                        error(std::string("Error in callback: ") + e.what());
+                        std::cout << std::string("Error in async callback: ") + e.what() << std::endl;
+                        error(std::string("Error in async callback: ") + e.what());
                     } catch (...) {
-                        error("Error in callback.");
+                        std::cout << "Error in async callback." << std::endl;
+                        error("Error in async callback.");
                     }
                 });
             } break;

--- a/src/amulet/utils/signal/signal.hpp
+++ b/src/amulet/utils/signal/signal.hpp
@@ -7,10 +7,12 @@
 #include <thread>
 
 #include <amulet/utils/dll.hpp>
+#include <amulet/utils/logging/logging.hpp>
 #include <amulet/utils/weak.hpp>
 
 namespace Amulet {
 
+// Forward declare error in case logging.hpp could not be included above.
 AMULET_UTILS_EXPORT void error(const std::string& msg);
 
 enum class ConnectionMode {

--- a/src/amulet/utils/signal/signal.hpp
+++ b/src/amulet/utils/signal/signal.hpp
@@ -180,7 +180,7 @@ public:
                 } catch (const std::exception& e) {
                     error(std::string("Error in callback: ") + e.what());
                 } catch (...) {
-                    error(std::string("Error in callback."));
+                    error("Error in callback.");
                 }
             } break;
             case ConnectionMode::Async: {
@@ -203,7 +203,7 @@ public:
                     } catch (const std::exception& e) {
                         error(std::string("Error in callback: ") + e.what());
                     } catch (...) {
-                        error(std::string("Error in callback."));
+                        error("Error in callback.");
                     }
                 });
             } break;

--- a/tests/test_amulet_utils/__init__.py
+++ b/tests/test_amulet_utils/__init__.py
@@ -13,13 +13,13 @@ def _init() -> None:
     import sys
     import logging
 
-    logging.basicConfig(level=1, format="%(levelname)s - %(message)s")
+    logging.basicConfig(level=logging.DEBUG, format="%(levelname)s - %(message)s")
 
     # Import dependencies
     import amulet.utils.logging
 
     # Enable debug logging when running tests.
-    amulet.utils.logging.set_min_log_level(0)
+    amulet.utils.logging.set_min_log_level(logging.DEBUG)
 
     # This needs to be an absolute path otherwise it may get called twice
     # on different module objects and crashes when the interpreter shuts down.

--- a/tests/test_amulet_utils/test_logging.py
+++ b/tests/test_amulet_utils/test_logging.py
@@ -22,7 +22,7 @@ class LoggingTestCase(TestCase):
                 (30, "warning msg"),
                 (40, "error msg"),
                 (50, "critical msg"),
-                *[(i, str(i)) for i in range(0, 60, 5)],
+                *[(i, str(i)) for i in range(10, 60, 5)],
             ],
             messages,
         )
@@ -33,8 +33,8 @@ class LoggingTestCase(TestCase):
         from amulet.utils.logging import get_min_log_level, set_min_log_level
 
         # this is set to 0 for tests
-        self.assertEqual(0, get_min_log_level())
-        set_min_log_level(10)
         self.assertEqual(10, get_min_log_level())
         set_min_log_level(0)
         self.assertEqual(0, get_min_log_level())
+        set_min_log_level(10)
+        self.assertEqual(10, get_min_log_level())


### PR DESCRIPTION
Ensure the global logger outlives the event loop.
Switch back to debug.
Move min_log_level to a local static variable.