### PR TITLE
Clear cache and install through pip

### DIFF
--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -89,7 +89,9 @@ runs:
       if: steps.install.outcome == 'failure'
       shell: bash
       run: |
-        python -m pip install "${{ github.action_path }}"/../../../dist/amulet_utils-*.whl
+        cache_dir=$(python -m pip cache dir)
+        rm -rf "$cache_dir"/http*
+        python -m pip install --only-binary amulet-utils amulet-compiler-version${{ inputs.compiler-specifier }} pybind11${{ inputs.pybind11-specifier }} amulet-pybind11-extensions${{ inputs.pybind11-extensions-specifier }} amulet-utils${{ inputs.utils-specifier }}
 
     - name: Get __version__
       id: get-version


### PR DESCRIPTION
Pip uses an outdated value from the cache.
This is an attempt to make it realise a new version exists.
A delay may need to be added to allow the published library to propagate through pypi.