### PR TITLE
Improve temporary directory configuration

### DIFF
--- a/src/amulet/utils/__init__.py
+++ b/src/amulet/utils/__init__.py
@@ -14,11 +14,6 @@ def _init() -> None:
     import ctypes
     import platformdirs
 
-    os.environ.setdefault(
-        "CACHE_DIR", platformdirs.user_cache_dir("AmuletTeam", "AmuletTeam")
-    )
-    os.makedirs(os.environ["CACHE_DIR"], exist_ok=True)
-
     if sys.platform == "win32":
         lib_path = os.path.join(os.path.dirname(__file__), "amulet_utils.dll")
     elif sys.platform == "darwin":
@@ -35,5 +30,11 @@ def _init() -> None:
 
     init(sys.modules[__name__])
 
+    from .temp import set_temp_dir
+    cache_dir = os.environ.get("CACHE_DIR")
+    if cache_dir is None:
+        cache_dir = platformdirs.user_cache_dir("AmuletTeam", "AmuletTeam")
+    os.makedirs(cache_dir, exist_ok=True)
+    set_temp_dir(cache_dir)
 
 _init()

--- a/src/amulet/utils/__init__.py
+++ b/src/amulet/utils/__init__.py
@@ -31,10 +31,12 @@ def _init() -> None:
     init(sys.modules[__name__])
 
     from .temp import set_temp_dir
+
     cache_dir = os.environ.get("CACHE_DIR")
     if cache_dir is None:
         cache_dir = platformdirs.user_cache_dir("AmuletTeam", "AmuletTeam")
     os.makedirs(cache_dir, exist_ok=True)
     set_temp_dir(cache_dir)
+
 
 _init()

--- a/src/amulet/utils/__init__.pyi
+++ b/src/amulet/utils/__init__.pyi
@@ -10,6 +10,7 @@ from . import (
     matrix,
     numpy,
     task_manager,
+    temp,
 )
 
 __all__: list[str] = [
@@ -21,6 +22,7 @@ __all__: list[str] = [
     "matrix",
     "numpy",
     "task_manager",
+    "temp",
 ]
 
 def _init() -> None: ...

--- a/src/amulet/utils/_amulet_utils.py.cpp
+++ b/src/amulet/utils/_amulet_utils.py.cpp
@@ -13,6 +13,7 @@ void init_lock(py::module);
 void init_logging(py::module);
 void init_image(py::module);
 void init_matrix(py::module);
+void init_temp(py::module);
 
 void init_module(py::module m)
 {
@@ -31,6 +32,7 @@ void init_module(py::module m)
     init_logging(m);
     init_image(m);
     init_matrix(m);
+    init_temp(m);
 }
 
 PYBIND11_MODULE(_amulet_utils, m)

--- a/src/amulet/utils/temp.cpp
+++ b/src/amulet/utils/temp.cpp
@@ -3,22 +3,66 @@
 #include <chrono>
 #include <cstdlib>
 #include <filesystem>
+#include <mutex>
 
 #include "lock_file.hpp"
 
 namespace Amulet {
 
+std::filesystem::path& _get_temp_dir()
+{
+    static std::filesystem::path _temp_dir = "";
+    return _temp_dir;
+}
+
+std::mutex& _get_temp_dir_mutex()
+{
+    static std::mutex _temp_dir_mutex;
+    return _temp_dir_mutex;
+}
+
+static void clean_temp_dir(const std::filesystem::path& temp_dir)
+{
+    for (const auto& group : std::filesystem::directory_iterator(temp_dir)) {
+        if (!group.is_directory()) {
+            continue;
+        }
+        for (const auto& dir : std::filesystem::directory_iterator(group.path())) {
+            if (!dir.path().filename().string().starts_with("amulettmp-")) {
+                continue;
+            }
+            try {
+                Amulet::LockFile lock(dir.path() / "lock");
+            } catch (const std::runtime_error&) {
+                continue;
+            }
+            std::filesystem::remove_all(dir.path());
+        }
+    }
+};
+
 std::filesystem::path get_temp_dir()
 {
-    auto* path_ptr = std::getenv("CACHE_DIR");
-    if (path_ptr == nullptr) {
-        throw std::runtime_error("Environment variable CACHE_DIR does not exist.");
+    std::lock_guard lock(_get_temp_dir_mutex());
+    auto& temp_dir = _get_temp_dir();
+    if (temp_dir.empty()) {
+        throw std::runtime_error("Temporary directory has not been set.");
     }
-    std::filesystem::path path(path_ptr);
+    return temp_dir;
+}
+
+void set_temp_dir(std::filesystem::path path)
+{
     if (!std::filesystem::is_directory(path)) {
-        throw std::runtime_error("Environment variable CACHE_DIR is not a directory.");
+        throw std::runtime_error("Temporary path is not a directory.");
     }
-    return path;
+    std::lock_guard lock(_get_temp_dir_mutex());
+    auto& temp_dir = _get_temp_dir();
+    if (!temp_dir.empty()) {
+        clean_temp_dir(temp_dir);
+    }
+    temp_dir = std::move(path);
+    clean_temp_dir(temp_dir);
 }
 
 TempDir::TempDir(const std::string& group)
@@ -41,42 +85,17 @@ TempDir::TempDir(const std::string& group)
 }
 
 TempDir::TempDir(TempDir&&) = default;
-TempDir& TempDir::operator = (TempDir&&) = default;
+TempDir& TempDir::operator=(TempDir&&) = default;
 
-TempDir::~TempDir() {
+TempDir::~TempDir()
+{
     _lock.reset();
     std::filesystem::remove_all(_path);
 }
 
-const std::filesystem::path& TempDir::get_path() const {
+const std::filesystem::path& TempDir::get_path() const
+{
     return _path;
 }
 
 } // namespace Amulet
-
-static const bool cleared_temp_dirs = [] {
-    std::filesystem::path temp_dir;
-    try {
-        temp_dir = Amulet::get_temp_dir();
-    } catch (const std::runtime_error&) {
-        return true;
-    }
-    
-    for (const auto& group : std::filesystem::directory_iterator(temp_dir)) {
-        if (!group.is_directory()) {
-            continue;
-        }
-        for (const auto& dir : std::filesystem::directory_iterator(group.path())) {
-            if (!dir.path().filename().string().starts_with("amulettmp-")) {
-                continue;
-            }
-            try {
-                Amulet::LockFile lock(dir.path() / "lock");
-            } catch (const std::runtime_error&) {
-                continue;
-            }
-            std::filesystem::remove_all(dir.path());
-        }
-    }
-    return true;
-}();

--- a/src/amulet/utils/temp.hpp
+++ b/src/amulet/utils/temp.hpp
@@ -15,6 +15,11 @@ namespace Amulet {
 // Thread safe.
 AMULET_UTILS_EXPORT std::filesystem::path get_temp_dir();
 
+// Set the temporary directory path.
+// It must be a path to an existing directory.
+// Anything using the previous path will continue using that path.
+AMULET_UTILS_EXPORT void set_temp_dir(std::filesystem::path);
+
 // A temporary directory to do with as you wish.
 class TempDir {
 private:

--- a/src/amulet/utils/temp.py.cpp
+++ b/src/amulet/utils/temp.py.cpp
@@ -1,0 +1,26 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/stl/filesystem.h>
+
+#include "temp.hpp"
+
+namespace py = pybind11;
+
+void init_temp(py::module m_parent)
+{
+    auto m = m_parent.def_submodule("temp");
+
+    m.def(
+        "get_temp_dir",
+        Amulet::get_temp_dir,
+        py::doc("Get the directory in which temporary directories will be created.\n"
+                "This is configurable by setting the \"CACHE_DIR\" environment variable.\n"
+                "Thread safe."));
+
+    m.def(
+        "set_temp_dir",
+        Amulet::set_temp_dir,
+        py::arg("path"),
+        py::doc("Set the temporary directory path.\n"
+                "It must be a path to an existing directory.\n"
+                "Anything using the previous path will continue using that path."));
+}

--- a/src/amulet/utils/temp.pyi
+++ b/src/amulet/utils/temp.pyi
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import os
+import pathlib
+
+__all__: list[str] = ["get_temp_dir", "set_temp_dir"]
+
+def get_temp_dir() -> pathlib.Path:
+    """
+    Get the directory in which temporary directories will be created.
+    This is configurable by setting the "CACHE_DIR" environment variable.
+    Thread safe.
+    """
+
+def set_temp_dir(path: os.PathLike | str | bytes) -> None:
+    """
+    Set the temporary directory path.
+    It must be a path to an existing directory.
+    Anything using the previous path will continue using that path.
+    """


### PR DESCRIPTION
If never set, this library will pick a sensible default.
Dependents can configure this location with set_temp_dir.
Add python bindings for get_temp_dir and set_temp_dir.