### PR TITLE
Add a map view class

### DIFF
--- a/src/amulet/utils/view/map_view.hpp
+++ b/src/amulet/utils/view/map_view.hpp
@@ -1,0 +1,130 @@
+#pragma once
+
+namespace Amulet {
+
+// There are some cases where I want to expose a const view to a map of smart pointers.
+// Const does not carry to the pointed object so this is a workaround.
+
+template <typename MapT, typename VT>
+class MapViewIterator {
+    static_assert(
+        std::is_convertible_v<typename MapT::mapped_type, VT>,
+        "MapView: VT must be convertible from MapT::mapped_type");
+
+public:
+    using value_type = std::pair<typename MapT::key_type, VT>;
+
+private:
+    typename MapT::const_iterator _it;
+    mutable value_type _value;
+
+public:
+    MapViewIterator(typename MapT::const_iterator it)
+        : _it(it)
+    {
+    }
+
+    value_type operator*() const
+    {
+        return { _it->first, _it->second };
+    }
+
+    const value_type* operator->() const
+    {
+        _value = operator*();
+        return &_value;
+    }
+
+    MapViewIterator& operator++()
+    {
+        ++_it;
+        return *this;
+    }
+
+    MapViewIterator operator++(int)
+    {
+        MapViewIterator tmp = *this;
+        ++_it;
+        return tmp;
+    }
+
+    bool operator==(const MapViewIterator& other) const
+    {
+        return _it == other._it;
+    }
+
+    bool operator!=(const MapViewIterator& other) const
+    {
+        return !(*this == other);
+    }
+};
+
+template <typename MapT, typename VT>
+class MapView {
+    static_assert(
+        std::is_convertible_v<typename MapT::mapped_type, VT>,
+        "MapView: VT must be convertible from MapT::mapped_type");
+
+private:
+    const MapT& _map;
+
+public:
+    using iterator = MapViewIterator<MapT, VT>;
+    using const_iterator = MapViewIterator<MapT, VT>;
+
+    MapView(const MapT& map)
+        : _map(map)
+    {
+    }
+
+    template <typename... Args>
+    VT at(Args&&... args) const
+    {
+        return _map.at(std::forward<Args>(args)...);
+    }
+
+    MapViewIterator<MapT, VT> begin() const
+    {
+        return _map.begin();
+    }
+
+    MapViewIterator<MapT, VT> end() const
+    {
+        return _map.end();
+    }
+
+    bool empty() const
+    {
+        return _map.empty();
+    }
+
+    typename MapT::size_type size() const
+    {
+        return _map.size();
+    }
+
+    typename MapT::size_type max_size() const
+    {
+        return _map.max_size();
+    }
+
+    template <typename... Args>
+    typename MapT::size_type count(Args&&... args) const
+    {
+        return _map.count(std::forward<Args>(args)...);
+    }
+
+    template <typename... Args>
+    MapViewIterator<MapT, VT> find(Args&&... args) const
+    {
+        return _map.find(std::forward<Args>(args)...);
+    }
+
+    template <typename... Args>
+    bool contains(Args&&... args) const
+    {
+        return _map.contains(std::forward<Args>(args)...);
+    }
+};
+
+} // namespace Amulet

--- a/tests/test_amulet_utils/__init__.pyi
+++ b/tests/test_amulet_utils/__init__.pyi
@@ -12,6 +12,7 @@ from . import (
     test_matrix_,
     test_task_manager_,
     test_temp_,
+    test_view_,
     test_weak_,
 )
 
@@ -25,6 +26,7 @@ __all__: list[str] = [
     "test_matrix_",
     "test_task_manager_",
     "test_temp_",
+    "test_view_",
     "test_weak_",
 ]
 

--- a/tests/test_amulet_utils/_test_amulet_utils.py.cpp
+++ b/tests/test_amulet_utils/_test_amulet_utils.py.cpp
@@ -14,6 +14,7 @@ void init_test_lock_file(py::module);
 void init_test_temp(py::module);
 void init_test_matrix(py::module);
 void init_test_bytes(py::module);
+void init_test_view(py::module);
 
 void init_module(py::module m){
     pyext::init_compiler_config(m);
@@ -28,6 +29,7 @@ void init_module(py::module m){
     init_test_temp(m);
     init_test_matrix(m);
     init_test_bytes(m);
+    init_test_view(m);
 }
 
 PYBIND11_MODULE(_test_amulet_utils, m) {

--- a/tests/test_amulet_utils/test_view.py
+++ b/tests/test_amulet_utils/test_view.py
@@ -1,0 +1,8 @@
+import unittest
+
+
+class MapViewTestCase(unittest.TestCase):
+    def test_map_view(self) -> None:
+        from test_amulet_utils.test_view_ import test_map_view
+
+        test_map_view()

--- a/tests/test_amulet_utils/test_view_.py.cpp
+++ b/tests/test_amulet_utils/test_view_.py.cpp
@@ -1,0 +1,103 @@
+#include <pybind11/pybind11.h>
+
+#include <map>
+#include <memory>
+#include <stdexcept>
+
+#include <amulet/utils/view/map_view.hpp>
+
+#include <amulet/test_utils/test_utils.hpp>
+
+namespace py = pybind11;
+
+static void test_view()
+{
+    using View = Amulet::MapView<std::map<int, std::shared_ptr<int>>, std::shared_ptr<const int>>;
+    using It = View::const_iterator;
+
+    std::map<int, std::shared_ptr<int>> m0;
+    View view_0(m0);
+
+    std::map<int, std::shared_ptr<int>> m3;
+    m3.emplace(1, std::make_shared<int>(2));
+    m3.emplace(3, std::make_shared<int>(4));
+    m3.emplace(5, std::make_shared<int>(6));
+    View view_3(m3);
+
+    // at
+    ASSERT_EQUAL(int, 2, *view_3.at(1));
+    ASSERT_EQUAL(int, 4, *view_3.at(3));
+    ASSERT_EQUAL(int, 6, *view_3.at(5));
+    ASSERT_RAISES(std::out_of_range, view_3.at(0));
+
+    // iteration
+    ASSERT_EQUAL(It, view_0.end(), view_0.begin());
+
+    auto it = view_3.begin();
+
+    ASSERT_NOT_EQUAL(It, view_3.end(), it);
+    ASSERT_EQUAL(int, 1, it->first);
+    ASSERT_EQUAL(int, 2, *it->second);
+
+    auto it2 = ++it;
+    ASSERT_NOT_EQUAL(It, view_3.end(), it);
+    auto item = *it;
+    ASSERT_EQUAL(int, 3, item.first);
+    ASSERT_EQUAL(int, 4, *item.second);
+
+    auto it3 = it++;
+    ASSERT_NOT_EQUAL(It, view_3.end(), it);
+    ASSERT_EQUAL(int, 5, it->first);
+    ASSERT_EQUAL(int, 6, *it->second);
+
+    it++;
+    ASSERT_EQUAL(It, view_3.end(), it);
+
+    ASSERT_EQUAL(It, it2, it3);
+    ASSERT_EQUAL(int, 3, it2->first);
+    ASSERT_EQUAL(int, 4, *it2->second);
+
+    // empty
+    ASSERT_TRUE(view_0.empty());
+    ASSERT_FALSE(view_3.empty());
+
+    // size
+    ASSERT_EQUAL(size_t, 0, view_0.size());
+    ASSERT_EQUAL(size_t, 3, view_3.size());
+
+    // max_size
+    ASSERT_LESS(size_t, 1'000'000, view_0.max_size());
+    ASSERT_LESS(size_t, 1'000'000, view_3.max_size());
+
+    // count
+    ASSERT_EQUAL(size_t, 0, view_3.count(0));
+    ASSERT_EQUAL(size_t, 1, view_3.count(1));
+    ASSERT_EQUAL(size_t, 0, view_3.count(2));
+    ASSERT_EQUAL(size_t, 1, view_3.count(3));
+    ASSERT_EQUAL(size_t, 0, view_3.count(4));
+    ASSERT_EQUAL(size_t, 1, view_3.count(5));
+    ASSERT_EQUAL(size_t, 0, view_3.count(6));
+
+    // find
+    auto find_it_0 = view_3.find(0);
+    ASSERT_EQUAL(It, view_3.end(), find_it_0);
+    auto find_it_1 = view_3.find(1);
+    ASSERT_NOT_EQUAL(It, view_3.end(), find_it_1);
+    ASSERT_EQUAL(int, 1, find_it_1->first);
+    ASSERT_EQUAL(int, 2, *find_it_1->second);
+
+    // contains
+    ASSERT_FALSE(view_3.contains(0));
+    ASSERT_TRUE(view_3.contains(1));
+    ASSERT_FALSE(view_3.contains(2));
+    ASSERT_TRUE(view_3.contains(3));
+    ASSERT_FALSE(view_3.contains(4));
+    ASSERT_TRUE(view_3.contains(5));
+    ASSERT_FALSE(view_3.contains(6));
+}
+
+void init_test_view(py::module m_parent)
+{
+    auto m = m_parent.def_submodule("test_view_");
+    m.def("test_map_view", &test_view);
+}

--- a/tests/test_amulet_utils/test_view_.pyi
+++ b/tests/test_amulet_utils/test_view_.pyi
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+__all__: list[str] = ["test_map_view"]
+
+def test_map_view() -> None: ...


### PR DESCRIPTION
This allows users to view maps storing smart pointers in a const context without accidental mutation.