### PR TITLE
Limit Bytes constructor and operator=

### DIFF
--- a/src/amulet/utils/bytes.hpp
+++ b/src/amulet/utils/bytes.hpp
@@ -8,15 +8,17 @@ namespace Amulet {
 class Bytes : public std::string {
 public:
     template <typename... Args>
+        requires std::constructible_from<std::string, Args...>
     Bytes(Args&&... args)
         : std::string(std::forward<Args>(args)...)
     {
     }
 
-    template <typename... Args>
-    Bytes& operator=(Args&&... args)
+    template <typename Arg>
+        requires std::assignable_from<std::string&, Arg>
+    Bytes& operator=(Arg&& arg)
     {
-        std::string::operator=(std::forward<Args>(args)...);
+        std::string::operator=(std::forward<Arg>(arg));
         return *this;
     }
 };


### PR DESCRIPTION
These functions would catch arguments they did not support that caused issues.